### PR TITLE
feature-add-ssg-adaptor

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,15 +3,15 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
 	preprocess: vitePreprocess(),
-
 	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter()
+		adapter: adapter({
+			pages: 'build',
+			assets: 'build',
+			fallback: undefined,
+			precompress: false,
+			strict: true
+		})
 	}
 };
 


### PR DESCRIPTION
## 変更内容

- ビルド方式をSSG に変更する

## 動作確認

- [x] 動作確認
- [x] キャプチャ（フロントエンドの場合）

![image](https://github.com/user-attachments/assets/7749b30c-b47e-4c8d-becf-b0f4f01c47c6)

```
PS C:\Users\pizam\Desktop\Work\Tora29-Lab> npm run build

> tora29-lab@0.0.1 build
> vite build

vite v5.4.11 building SSR bundle for production...
✓ 154 modules transformed.
vite v5.4.11 building for production...
✓ 133 modules transformed.
.svelte-kit/output/client/_app/version.json                        0.03 kB │ gzip:  0.05 kB
.svelte-kit/output/client/.vite/manifest.json                      2.77 kB │ gzip:  0.56 kB
.svelte-kit/output/client/_app/immutable/assets/0.BpAVHVrk.css     4.79 kB │ gzip:  1.40 kB
.svelte-kit/output/client/_app/immutable/chunks/B4tXcM_Z.js        0.03 kB │ gzip:  0.05 kB
.svelte-kit/output/client/_app/immutable/entry/start.DLO8XfqP.js   0.06 kB │ gzip:  0.08 kB
.svelte-kit/output/client/_app/immutable/chunks/OFZvW94L.js        0.32 kB │ gzip:  0.25 kB
.svelte-kit/output/client/_app/immutable/nodes/2.CIvjz5JQ.js       0.33 kB │ gzip:  0.25 kB
.svelte-kit/output/client/_app/immutable/nodes/0.DHJAfCp6.js       0.49 kB │ gzip:  0.35 kB
.svelte-kit/output/client/_app/immutable/chunks/CTJJnQPU.js        0.97 kB │ gzip:  0.55 kB
.svelte-kit/output/client/_app/immutable/nodes/1.CWCjMbbR.js       1.22 kB │ gzip:  0.66 kB
.svelte-kit/output/client/_app/immutable/chunks/BgIOBhBJ.js        2.47 kB │ gzip:  1.36 kB
.svelte-kit/output/client/_app/immutable/entry/app.CRtMYgjs.js     9.52 kB │ gzip:  4.36 kB
.svelte-kit/output/client/_app/immutable/chunks/BVth93n8.js       12.68 kB │ gzip:  5.16 kB
.svelte-kit/output/client/_app/immutable/chunks/-y9tcVKd.js       31.84 kB │ gzip: 12.40 kB
✓ built in 506ms
.svelte-kit/output/server/.vite/manifest.json                          1.94 kB
.svelte-kit/output/server/_app/immutable/assets/_layout.BpAVHVrk.css   4.79 kB
.svelte-kit/output/server/entries/pages/_layout.ts.js                  0.05 kB
.svelte-kit/output/server/entries/pages/_page.svelte.js                0.23 kB
.svelte-kit/output/server/entries/pages/_layout.svelte.js              0.25 kB
.svelte-kit/output/server/internal.js                                  0.31 kB
.svelte-kit/output/server/chunks/equality.js                           0.67 kB
.svelte-kit/output/server/chunks/index.js                              2.30 kB
.svelte-kit/output/server/entries/fallbacks/error.svelte.js            3.10 kB
.svelte-kit/output/server/chunks/exports.js                            7.54 kB
.svelte-kit/output/server/chunks/internal.js                          43.27 kB
.svelte-kit/output/server/index.js                                    95.83 kB
✓ built in 2.67s

Run npm run preview to preview your production build locally.

> Using @sveltejs/adapter-static
  Wrote site to "build"
  ✔ done
```

## 関連するIssue

- [x] Issue のリンク
https://github.com/Tora29/Tora29-Lab/issues/1

## 補足

追加で注意事項や補足情報があれば
