### PR TITLE
画像の指定を絶対パスに変更

### DIFF
--- a/src/lib/components/display/DisplayMainLogo.svelte
+++ b/src/lib/components/display/DisplayMainLogo.svelte
@@ -17,7 +17,7 @@
 		align-items: center;
 		width: 100%;
 		height: 500px;
-		background-image: url('img/main-logo.webp');
+		background-image: url('/img/main-logo.webp');
 		background-size: cover;
 		background-position: center;
 


### PR DESCRIPTION
## 変更内容

- メインロゴの指定方法を絶対パスに変更

## 動作確認

- [x] 動作確認
- [x] キャプチャ（フロントエンドの場合）

（ブラウザ）
![image](https://github.com/user-attachments/assets/401f93ab-065d-47bf-8fe9-76992219b68d)

（スマホ）
![image](https://github.com/user-attachments/assets/a029237c-91a9-4138-b73d-a191a1ad1ba3)

## 関連するIssue

- [x] Issue のリンク
https://github.com/Tora29/Tora29-Lab/issues/7

## 補足
なし
